### PR TITLE
Preventing getting outdated packages

### DIFF
--- a/chapter7/complete/client/Dockerfile
+++ b/chapter7/complete/client/Dockerfile
@@ -4,6 +4,6 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
 
 FROM alpine
-RUN apk add --no-cache ca-certificates
+RUN apk update && apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/scottwinkler/helloworld/helloworld /helloworld
 CMD ["/helloworld"]


### PR DESCRIPTION
Hi,
I don't know why you install this package but I believe it is best practice to run `apk update` and `apk add` in the same operation (Tip #3 https://blog.docker.com/2019/07/intro-guide-to-dockerfile-best-practices/). 

Cheers!